### PR TITLE
Exposes more functions to the Updater prototype, fixes missing dirs

### DIFF
--- a/__tests__/tnArticleHelpers.test.js
+++ b/__tests__/tnArticleHelpers.test.js
@@ -1,6 +1,5 @@
 /* eslint-disable quotes */
 /* eslint-env jest */
-jest.unmock('fs-extra');
 import fs from 'fs-extra';
 import path from 'path-extra';
 import ospath from 'ospath';
@@ -17,19 +16,7 @@ const mockGetMissingOriginalResource = async (resourcesPath, originalLanguageId,
 
 describe('Tests for tnArticleHelpers.getMissingResources()', function() {
   beforeEach(() => {
-    // fs.__resetMockFS();
-  });
-
-  it('Test tN', async () => {
-    const resource = {
-      languageId: 'en',
-      resourceId: 'ult',
-      downloadUrl: 'https://test.com',
-    };
-    const resourcesPath = '/Users/richmahn/working/resources';
-    const tnGroupDataPath = path.join(resourcesPath, 'en/translationHelps/translationNotes/v22');
-    const tnRepoPath = '/Users/richmahn/working/en_tn';
-    tnArticleHelpers.processTranslationNotes(resource, tnRepoPath, tnGroupDataPath, resourcesPath);
+    fs.__resetMockFS();
   });
 
   it('Test for en with no dependencies', async () => {

--- a/__tests__/tnArticleHelpers.test.js
+++ b/__tests__/tnArticleHelpers.test.js
@@ -1,5 +1,6 @@
 /* eslint-disable quotes */
 /* eslint-env jest */
+jest.unmock('fs-extra');
 import fs from 'fs-extra';
 import path from 'path-extra';
 import ospath from 'ospath';
@@ -15,9 +16,20 @@ const mockGetMissingOriginalResource = async (resourcesPath, originalLanguageId,
 };
 
 describe('Tests for tnArticleHelpers.getMissingResources()', function() {
-
   beforeEach(() => {
-    fs.__resetMockFS();
+    // fs.__resetMockFS();
+  });
+
+  it('Test tN', async () => {
+    const resource = {
+      languageId: 'en',
+      resourceId: 'ult',
+      downloadUrl: 'https://test.com',
+    };
+    const resourcesPath = '/Users/richmahn/working/resources';
+    const tnGroupDataPath = path.join(resourcesPath, 'en/translationHelps/translationNotes/v22');
+    const tnRepoPath = '/Users/richmahn/working/en_tn';
+    tnArticleHelpers.processTranslationNotes(resource, tnRepoPath, tnGroupDataPath, resourcesPath);
   });
 
   it('Test for en with no dependencies', async () => {
@@ -85,7 +97,7 @@ describe('Tests for tnArticleHelpers.getMissingResources()', function() {
  * @param {Array} callLog
  */
 function cleanUpPaths(callLog) {
-  const newLog = callLog.map(item => {
+  const newLog = callLog.map((item) => {
     const newItem = {...item};
     if (item.resourcesPath) {
       const newPath = item.resourcesPath.replace(ospath.home(), '<HOME>');

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tc-source-content-updater",
-  "version": "0.6.16-beta",
+  "version": "0.6.16-beta2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2451,28 +2451,28 @@
       "dependencies": {
         "abbrev": {
           "version": "1.1.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
           "dev": true,
           "optional": true
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "dev": true,
           "optional": true
         },
         "aproba": {
           "version": "1.2.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
           "dev": true,
           "optional": true
         },
         "are-we-there-yet": {
           "version": "1.1.5",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
           "dev": true,
           "optional": true,
@@ -2483,14 +2483,14 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
           "dev": true,
           "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
           "optional": true,
@@ -2501,42 +2501,42 @@
         },
         "chownr": {
           "version": "1.1.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
           "dev": true,
           "optional": true
         },
         "code-point-at": {
           "version": "1.1.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
           "dev": true,
           "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
           "dev": true,
           "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
           "dev": true,
           "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
           "dev": true,
           "optional": true
         },
         "debug": {
           "version": "4.1.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "dev": true,
           "optional": true,
@@ -2546,28 +2546,28 @@
         },
         "deep-extend": {
           "version": "0.6.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
           "dev": true,
           "optional": true
         },
         "delegates": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
           "dev": true,
           "optional": true
         },
         "detect-libc": {
           "version": "1.0.3",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
           "dev": true,
           "optional": true
         },
         "fs-minipass": {
           "version": "1.2.5",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
           "dev": true,
           "optional": true,
@@ -2577,14 +2577,14 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
           "dev": true,
           "optional": true
         },
         "gauge": {
           "version": "2.7.4",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
           "dev": true,
           "optional": true,
@@ -2601,7 +2601,7 @@
         },
         "glob": {
           "version": "7.1.3",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
           "dev": true,
           "optional": true,
@@ -2616,14 +2616,14 @@
         },
         "has-unicode": {
           "version": "2.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
           "dev": true,
           "optional": true
         },
         "iconv-lite": {
           "version": "0.4.24",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
           "dev": true,
           "optional": true,
@@ -2633,7 +2633,7 @@
         },
         "ignore-walk": {
           "version": "3.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
           "dev": true,
           "optional": true,
@@ -2643,7 +2643,7 @@
         },
         "inflight": {
           "version": "1.0.6",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "dev": true,
           "optional": true,
@@ -2654,21 +2654,21 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
           "dev": true,
           "optional": true
         },
         "ini": {
           "version": "1.3.5",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
           "dev": true,
           "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "optional": true,
@@ -2678,14 +2678,14 @@
         },
         "isarray": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "dev": true,
           "optional": true
         },
         "minimatch": {
           "version": "3.0.4",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "optional": true,
@@ -2695,14 +2695,14 @@
         },
         "minimist": {
           "version": "0.0.8",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "dev": true,
           "optional": true
         },
         "minipass": {
           "version": "2.3.5",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
           "dev": true,
           "optional": true,
@@ -2713,7 +2713,7 @@
         },
         "minizlib": {
           "version": "1.2.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
           "dev": true,
           "optional": true,
@@ -2723,7 +2723,7 @@
         },
         "mkdirp": {
           "version": "0.5.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
           "optional": true,
@@ -2733,14 +2733,14 @@
         },
         "ms": {
           "version": "2.1.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
           "dev": true,
           "optional": true
         },
         "needle": {
           "version": "2.3.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-QBZu7aAFR0522EyaXZM0FZ9GLpq6lvQ3uq8gteiDUp7wKdy0lSd2hPlgFwVuW1CBkfEs9PfDQsQzZghLs/psdg==",
           "dev": true,
           "optional": true,
@@ -2752,7 +2752,7 @@
         },
         "node-pre-gyp": {
           "version": "0.12.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-4KghwV8vH5k+g2ylT+sLTjy5wmUOb9vPhnM8NHvRf9dHmnW/CndrFXy2aRPaPST6dugXSdHXfeaHQm77PIz/1A==",
           "dev": true,
           "optional": true,
@@ -2771,7 +2771,7 @@
         },
         "nopt": {
           "version": "4.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
           "dev": true,
           "optional": true,
@@ -2782,14 +2782,14 @@
         },
         "npm-bundled": {
           "version": "1.0.6",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-8/JCaftHwbd//k6y2rEWp6k1wxVfpFzB6t1p825+cUb7Ym2XQfhwIC5KwhrvzZRJu+LtDE585zVaS32+CGtf0g==",
           "dev": true,
           "optional": true
         },
         "npm-packlist": {
           "version": "1.4.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-+TcdO7HJJ8peiiYhvPxsEDhF3PJFGUGRcFsGve3vxvxdcpO2Z4Z7rkosRM0kWj6LfbK/P0gu3dzk5RU1ffvFcw==",
           "dev": true,
           "optional": true,
@@ -2800,7 +2800,7 @@
         },
         "npmlog": {
           "version": "4.1.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
           "dev": true,
           "optional": true,
@@ -2813,21 +2813,21 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
           "dev": true,
           "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
           "dev": true,
           "optional": true
         },
         "once": {
           "version": "1.4.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
           "optional": true,
@@ -2837,21 +2837,21 @@
         },
         "os-homedir": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
           "dev": true,
           "optional": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
           "dev": true,
           "optional": true
         },
         "osenv": {
           "version": "0.1.5",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
           "dev": true,
           "optional": true,
@@ -2862,21 +2862,21 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
           "dev": true,
           "optional": true
         },
         "process-nextick-args": {
           "version": "2.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
           "dev": true,
           "optional": true
         },
         "rc": {
           "version": "1.2.8",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
           "dev": true,
           "optional": true,
@@ -2889,7 +2889,7 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
               "dev": true,
               "optional": true
@@ -2898,7 +2898,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "optional": true,
@@ -2914,7 +2914,7 @@
         },
         "rimraf": {
           "version": "2.6.3",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
           "dev": true,
           "optional": true,
@@ -2924,49 +2924,49 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
           "dev": true,
           "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
           "dev": true,
           "optional": true
         },
         "sax": {
           "version": "1.2.4",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
           "dev": true,
           "optional": true
         },
         "semver": {
           "version": "5.7.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
           "dev": true,
           "optional": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
           "dev": true,
           "optional": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
           "dev": true,
           "optional": true
         },
         "string-width": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "optional": true,
@@ -2978,7 +2978,7 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "optional": true,
@@ -2988,7 +2988,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "optional": true,
@@ -2998,14 +2998,14 @@
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
           "dev": true,
           "optional": true
         },
         "tar": {
           "version": "4.4.8",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
           "dev": true,
           "optional": true,
@@ -3021,14 +3021,14 @@
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
           "dev": true,
           "optional": true
         },
         "wide-align": {
           "version": "1.1.3",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
           "dev": true,
           "optional": true,
@@ -3038,14 +3038,14 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
           "dev": true,
           "optional": true
         },
         "yallist": {
           "version": "3.0.3",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
           "dev": true,
           "optional": true

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tc-source-content-updater",
-  "version": "0.6.16-beta2",
+  "version": "0.6.16",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tc-source-content-updater",
-  "version": "0.6.15",
+  "version": "0.6.16-beta",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tc-source-content-updater",
-  "version": "0.6.15",
+  "version": "0.6.16-beta",
   "description": "Module that updates source content for the desktop application translationCore.",
   "main": "lib/index.js",
   "display": "library",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tc-source-content-updater",
-  "version": "0.6.16-beta2",
+  "version": "0.6.16",
   "description": "Module that updates source content for the desktop application translationCore.",
   "main": "lib/index.js",
   "display": "library",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tc-source-content-updater",
-  "version": "0.6.16-beta",
+  "version": "0.6.16-beta2",
   "description": "Module that updates source content for the desktop application translationCore.",
   "main": "lib/index.js",
   "display": "library",

--- a/src/helpers/packageParseHelpers.js
+++ b/src/helpers/packageParseHelpers.js
@@ -22,7 +22,6 @@ import * as errors from '../resources/errors';
 export const parseUsfmOfBook = (usfmPath, outputPath) => {
   const usfmData = fs.readFileSync(usfmPath, 'UTF-8').toString();
   const converted = usfm.toJSON(usfmData, {convertToInt: ['occurrence', 'occurrences']});
-
   const {chapters} = converted;
   Object.keys(chapters).forEach((chapter) => {
     fs.outputFileSync(path.join(outputPath, chapter + '.json'), JSON.stringify(chapters[chapter], null, 2));

--- a/src/helpers/packageParseHelpers.js
+++ b/src/helpers/packageParseHelpers.js
@@ -22,7 +22,8 @@ import * as errors from '../resources/errors';
 export const parseUsfmOfBook = (usfmPath, outputPath) => {
   const usfmData = fs.readFileSync(usfmPath, 'UTF-8').toString();
   const converted = usfm.toJSON(usfmData, {convertToInt: ['occurrence', 'occurrences']});
-  const {chapters} = converted;
+
+  const { chapters } = converted;
   Object.keys(chapters).forEach((chapter) => {
     fs.outputFileSync(path.join(outputPath, chapter + '.json'), JSON.stringify(chapters[chapter], null, 2));
   });
@@ -68,6 +69,9 @@ export function parseBiblePackage(resource, sourcePath, outputPath) {
   }
   if (!outputPath) {
     throw Error(resourcesHelpers.formatError(resource, errors.OUTPUT_PATH_NOT_GIVEN));
+  }
+  if (!fs.pathExistsSync(outputPath)) {
+    fs.mkdirSync(outputPath, {recursive: true});
   }
   try {
     const isOL = (resource.resourceId === 'ugnt') || (resource.resourceId === 'uhb');

--- a/src/helpers/packageParseHelpers.js
+++ b/src/helpers/packageParseHelpers.js
@@ -23,7 +23,7 @@ export const parseUsfmOfBook = (usfmPath, outputPath) => {
   const usfmData = fs.readFileSync(usfmPath, 'UTF-8').toString();
   const converted = usfm.toJSON(usfmData, {convertToInt: ['occurrence', 'occurrences']});
 
-  const { chapters } = converted;
+  const {chapters} = converted;
   Object.keys(chapters).forEach((chapter) => {
     fs.outputFileSync(path.join(outputPath, chapter + '.json'), JSON.stringify(chapters[chapter], null, 2));
   });

--- a/src/helpers/packageParseHelpers.js
+++ b/src/helpers/packageParseHelpers.js
@@ -69,9 +69,7 @@ export function parseBiblePackage(resource, sourcePath, outputPath) {
   if (!outputPath) {
     throw Error(resourcesHelpers.formatError(resource, errors.OUTPUT_PATH_NOT_GIVEN));
   }
-  if (!fs.pathExistsSync(outputPath)) {
-    fs.mkdirSync(outputPath, {recursive: true});
-  }
+  fs.ensureDirSync(outputPath);
   try {
     const isOL = (resource.resourceId === 'ugnt') || (resource.resourceId === 'uhb');
     const manifest = parseManifest(sourcePath, outputPath);

--- a/src/helpers/translationHelps/tnArticleHelpers.js
+++ b/src/helpers/translationHelps/tnArticleHelpers.js
@@ -1,7 +1,6 @@
 import fs from 'fs-extra';
 import path from 'path-extra';
 import {isObject} from 'util';
-import ospath from 'ospath';
 import {
   tsvToGroupData,
   formatAndSaveGroupData,

--- a/src/helpers/translationHelps/tnArticleHelpers.js
+++ b/src/helpers/translationHelps/tnArticleHelpers.js
@@ -21,7 +21,7 @@ import {
   BOOK_CHAPTER_VERSES,
   BIBLE_LIST_NT,
 } from '../../resources/bible';
-import {makeSureResourceUnzipped} from "../unzipFileHelpers";
+import {makeSureResourceUnzipped} from '../unzipFileHelpers';
 
 /**
  * search to see if we need to get any missing original language dependencies

--- a/src/helpers/translationHelps/tnArticleHelpers.js
+++ b/src/helpers/translationHelps/tnArticleHelpers.js
@@ -13,6 +13,7 @@ import * as resourcesHelpers from '../resourcesHelpers';
 import {downloadAndProcessResource} from '../resourcesDownloadHelpers';
 import {delay, getQueryStringForBibleId, getQueryVariable} from '../utils';
 // constants
+import * as errors from '../../resources/errors';
 import {
   OT_ORIG_LANG,
   NT_ORIG_LANG,
@@ -91,7 +92,7 @@ export async function processTranslationNotes(resource, sourcePath, outputPath, 
     const {otQuery, ntQuery} = await getMissingResources(sourcePath, resourcesPath, getMissingOriginalResource, downloadErrors);
     console.log(`processTranslationNotes() - have needed original bibles for ${sourcePath}, starting processing`);
     const tsvFiles = fs.readdirSync(sourcePath).filter((filename) => path.extname(filename) === '.tsv');
-    const errors = [];
+    const tnErrors = [];
 
     tsvFiles.forEach(async (filename) => {
       try {
@@ -121,19 +122,19 @@ export async function processTranslationNotes(resource, sourcePath, outputPath, 
         } else {
           const message = `processTranslationNotes() - cannot find original bible ${originalBiblePath}:`;
           console.error(message);
-          errors.push(message);
+          tnErrors.push(message);
         }
       } catch (e) {
         const message = `processTranslationNotes() - error processing ${filename}:`;
         console.error(message, e);
-        errors.push(message + e.toString());
+        tnErrors.push(message + e.toString());
       }
     });
 
-    if (errors.length) { // report errors
+    if (tnErrors.length) { // report errors
       const message = `processTranslationNotes() - error processing ${sourcePath}`;
       console.error(message);
-      throw new Error(`${message}:\n${errors.join('\n')}`);
+      throw new Error(`${message}:\n${tnErrors.join('\n')}`);
     }
 
     await delay(200);
@@ -231,14 +232,16 @@ export function getOtherTnsOLVersions(resourcesPath, originalLanguageId) {
     const tnHelpsPath = path.join(resourcesPath, languageId, 'translationHelps', 'translationNotes');
     if (fs.existsSync(tnHelpsPath)) {
       const tnHelpsVersionPath = resourcesHelpers.getLatestVersionInPath(tnHelpsPath);
-      const tnManifestPath = path.join(tnHelpsVersionPath, 'manifest.json');
-      if (fs.existsSync(tnManifestPath)) {
-        const manifest = fs.readJsonSync(tnManifestPath);
-        const {relation} = manifest.dublin_core || {};
-        const query = getQueryStringForBibleId(relation, originalLanguageId);
-        if (query) {
-          const version = 'v' + getQueryVariable(query, 'v');
-          versionsToNotDelete.push(version);
+      if (tnHelpsVersionPath) {
+        const tnManifestPath = path.join(tnHelpsVersionPath, 'manifest.json');
+        if (fs.existsSync(tnManifestPath)) {
+          const manifest = fs.readJsonSync(tnManifestPath);
+          const {relation} = manifest.dublin_core || {};
+          const query = getQueryStringForBibleId(relation, originalLanguageId);
+          if (query) {
+            const version = 'v' + getQueryVariable(query, 'v');
+            versionsToNotDelete.push(version);
+          }
         }
       }
     }

--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,7 @@ import * as packageParseHelpers from './helpers/packageParseHelpers';
 import * as taArticleHelpers from './helpers/translationHelps/taArticleHelpers';
 import * as twArticleHelpers from './helpers/translationHelps/twArticleHelpers';
 import * as twGroupDataHelpers from './helpers/translationHelps/twGroupDataHelpers';
+import * as tnArticleHelpers from './helpers/translationHelps/tnArticleHelpers';
 import * as resourcesDownloadHelpers from './helpers/resourcesDownloadHelpers';
 export {getOtherTnsOLVersions} from './helpers/translationHelps/tnArticleHelpers';
 
@@ -166,23 +167,25 @@ Updater.prototype.parseBiblePackage = function(resourceEntry, extractedFilesPath
 /**
  * @description Processes the extracted files for translationAcademy to create a single file for each
  * article
+ * @param {Object} resource Resource object
  * @param {String} extractedFilesPath - Path to the extracted files that came from the zip file in the catalog
  * @param {String} outputPath - Path to place the processed files WITHOUT version in the path
  * @return {String} The path to the processed translationAcademy files with version
  */
-Updater.prototype.processTranslationAcademy = function(extractedFilesPath, outputPath) {
-  return taArticleHelpers.processTranslationAcademy(extractedFilesPath, outputPath);
+Updater.prototype.processTranslationAcademy = function(resource, extractedFilesPath, outputPath) {
+  return taArticleHelpers.processTranslationAcademy(resource, extractedFilesPath, outputPath);
 };
 
 /**
  * @description Processes the extracted files for translationWord to cerate the folder
  * structure and produce the index.js file for the language with the title of each article.
+ * @param {Object} resource Resource object
  * @param {String} extractedFilesPath - Path to the extracted files that came from the zip file from the catalog
  * @param {String} outputPath - Path to place the processed resource files WIHTOUT the version in the path
  * @return {String} Path to the processed translationWords files with version
  */
-Updater.prototype.processTranslationWords = function(extractedFilesPath, outputPath) {
-  return twArticleHelpers.processTranslationWords(extractedFilesPath, outputPath);
+Updater.prototype.processTranslationWords = function(resource, extractedFilesPath, outputPath) {
+  return twArticleHelpers.processTranslationWords(resource, extractedFilesPath, outputPath);
 };
 
 /**
@@ -194,6 +197,18 @@ Updater.prototype.processTranslationWords = function(extractedFilesPath, outputP
  */
 Updater.prototype.generateTwGroupDataFromAlignedBible = function(resource, biblePath, outputPath) {
   return twGroupDataHelpers.generateTwGroupDataFromAlignedBible(resource, biblePath, outputPath);
+};
+
+/**
+ * @description Processes the extracted files for translationNotes to separate the folder
+ * structure and produce the index.json file for the language with the title of each article.
+ * @param {Object} resource - Resource object
+ * @param {String} sourcePath - Path to the extracted files that came from the zip file from the catalog
+ * @param {String} outputPath - Path to place the processed resource files WITHOUT the version in the path
+ * @param {String} resourcesPath Path to resources folder
+ */
+Updater.prototype.processTranslationNotes = function(resource, sourcePath, outputPath, resourcesPath) {
+  tnArticleHelpers.processTranslationNotes(resource, sourcePath, outputPath, resourcesPath, this.downloadErrors);
 };
 
 /**


### PR DESCRIPTION
I fixed a few more of the functions wrapped by Updater were not called properly, like my previous fix.

I also open up the `processTranslationNotes()` helper function like the Bible and TranslationAcademy functions.

Fixes when `<lang>/translationHelps/translationNotes` dir exists but no version directories are within (`path.join()` was choking on a `null`)

in `tnArticleHelpers.js`, were were calling `errors.<CONST>` for error codes, but errors was also locally defined as an array, thus when those errors did occur, it was failing. I had it import the errors constant file, and renamed the array to `tnErrors`.

Remove unused modules, `ospath` from `tnArticleHelpers.js`.

Been published as `tc-source-content-updater@0.6.16-beta2` for trial.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword/tc-source-content-updater/118)
<!-- Reviewable:end -->
