### PR TITLE
Bugfix 6847/fix to show all target words in SP and word bank and better invalidation checking in WA

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tc-source-content-updater",
-  "version": "0.6.19",
+  "version": "0.6.20",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1169,6 +1169,7 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+      "dev": true,
       "requires": {
         "core-js": "^2.4.0",
         "regenerator-runtime": "^0.11.0"
@@ -1684,7 +1685,8 @@
     "core-js": {
       "version": "2.6.11",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
-      "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg=="
+      "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==",
+      "dev": true
     },
     "core-js-pure": {
       "version": "3.6.5",
@@ -4885,7 +4887,14 @@
     "lodash": {
       "version": "4.17.15",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "dev": true
+    },
+    "lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
+      "dev": true
     },
     "lodash.sortby": {
       "version": "4.7.0",
@@ -6172,7 +6181,8 @@
     "regenerator-runtime": {
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
+      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+      "dev": true
     },
     "regenerator-transform": {
       "version": "0.10.1",
@@ -6403,6 +6413,7 @@
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
       "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "dev": true,
       "requires": {
         "glob": "^7.1.3"
       }
@@ -7422,11 +7433,6 @@
         "punycode": "^2.1.0"
       }
     },
-    "transform-runtime": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/transform-runtime/-/transform-runtime-0.0.0.tgz",
-      "integrity": "sha1-5xTZtpIR3ZU3k51Q46pXiMRCuFw="
-    },
     "trim-right": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
@@ -7625,14 +7631,12 @@
       "dev": true
     },
     "usfm-js": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/usfm-js/-/usfm-js-2.0.2.tgz",
-      "integrity": "sha512-9dykXM14qzp8+hp73xr+qz1lljtDPApUukzD/Md/pB0Dp5sAicl7OJLXhBHbQVmOKigpRS+JexIaa9x+yBWWaw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/usfm-js/-/usfm-js-2.1.0.tgz",
+      "integrity": "sha512-DemzdzAwrVeuzRwnZYOKvAle/U2ZUUf04NQSVDgqZCSFyH7hVhe2/PWC7jT2DKnPMYoa0IxnG3XGbuOPXgZ/oQ==",
+      "dev": true,
       "requires": {
-        "babel-runtime": "^6.26.0",
-        "lodash": "^4.17.11",
-        "rimraf": "^2.6.3",
-        "transform-runtime": "0.0.0"
+        "lodash.clonedeep": "^4.5.0"
       }
     },
     "util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tc-source-content-updater",
-  "version": "0.6.19",
+  "version": "0.6.20",
   "description": "Module that updates source content for the desktop application translationCore.",
   "main": "lib/index.js",
   "display": "library",
@@ -62,7 +62,8 @@
     "rimraf": "^2.6.3",
     "string-punctuation-tokenizer": "2.0.0",
     "tmp": "0.0.33",
-    "tsv-groupdata-parser": "0.9.16"
+    "tsv-groupdata-parser": "0.9.16",
+    "usfm-js": "2.1.0"
   },
   "dependencies": {
     "adm-zip": "^0.4.11",
@@ -74,11 +75,11 @@
     "promise-parallel-throttle": "^3.3.0",
     "request": "^2.87.0",
     "url": "^0.11.0",
-    "usfm-js": "2.0.2",
     "yamljs": "^0.3.0"
   },
   "peerDependencies": {
     "string-punctuation-tokenizer": "^2.0.0",
-    "tsv-groupdata-parser": "^0.9.16"
+    "tsv-groupdata-parser": "^0.9.16",
+    "usfm-js": "^2.1.0"
   }
 }


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- updated usfm-js and made it a peer dependency

#### Please include detailed Test instructions for your pull request:
- checkout tC branch `bugfix-mcleanb-6847`, run `npm run load-apps && npm ci && npm start`
- use github build attached to https://github.com/unfoldingWord/translationCore/pull/6966
- open project at https://drive.google.com/open?id=1nkSWNnvqHw_QVDaU5dIzNf9GZetrEB4Y
- when you open project, should see 38 new invalidations for WA
- open WA and navigate to luke 4:19
- the old builds would not show invalidations until project was exported, and would only show `4:19 और का प्रचार करूँ।”` in SP and only 4 words in the word bank
- but in this build 4:19 should show invalidated icon.  Also you should see many more words in word bank and SP as:  
![Screen Shot 2020-06-04 at 10 07 47 AM copy](https://user-images.githubusercontent.com/14238574/83773109-20709680-a652-11ea-83d6-12f64bdd2b36.png)

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword/tc-source-content-updater/124)
<!-- Reviewable:end -->
